### PR TITLE
Make object and property separator in visualization configurable.

### DIFF
--- a/concepts/lattices.py
+++ b/concepts/lattices.py
@@ -379,10 +379,10 @@ class Lattice(object):
                         push(heap, (c.index, c))
 
     def graphviz(self, filename=None, directory=None, render=False, view=False,
-                 **kwargs):
+                 object_sep=' ', property_sep=' ', **kwargs):
         """Return graphviz source for visualizing the lattice graph."""
         return visualize.lattice(self, filename, directory, render, view,
-                                 **kwargs)
+                                 object_sep, property_sep, **kwargs)
 
 
 def _iterunion(concepts, sortkey, next_concepts):

--- a/concepts/visualize.py
+++ b/concepts/visualize.py
@@ -12,7 +12,8 @@ SORTKEYS = [lambda c: c.index]
 NAME_GETTERS = [lambda c: 'c%d' % c.index]
 
 
-def lattice(lattice, filename, directory, render, view, **kwargs):
+def lattice(lattice, filename, directory, render, view, separators,
+            **kwargs):
     """Return graphviz source for visualizing the lattice graph."""
     dot = graphviz.Digraph(name=lattice.__class__.__name__,
                            comment=repr(lattice),
@@ -32,12 +33,12 @@ def lattice(lattice, filename, directory, render, view, **kwargs):
 
         if concept.objects:
             dot.edge(name, name,
-                     headlabel=' '.join(concept.objects),
+                     headlabel=object_sep.join(concept.objects),
                      labelangle='270', color='transparent')
 
         if concept.properties:
             dot.edge(name, name,
-                     taillabel=' '.join(concept.properties),
+                     taillabel=property_sep.join(concept.properties),
                      labelangle='90', color='transparent')
 
         dot.edges((name, node_name(c))

--- a/concepts/visualize.py
+++ b/concepts/visualize.py
@@ -12,8 +12,8 @@ SORTKEYS = [lambda c: c.index]
 NAME_GETTERS = [lambda c: 'c%d' % c.index]
 
 
-def lattice(lattice, filename, directory, render, view, separators,
-            **kwargs):
+def lattice(lattice, filename, directory, render, view, object_sep,
+            property_sep, **kwargs):
     """Return graphviz source for visualizing the lattice graph."""
     dot = graphviz.Digraph(name=lattice.__class__.__name__,
                            comment=repr(lattice),

--- a/tests/test_lattices.py
+++ b/tests/test_lattices.py
@@ -151,3 +151,8 @@ def test_nonatomic():
     assert [tuple(c) for c in m] == [(('spam', 'eggs'), ('ham',))]
     t = Context(('spam', 'eggs'), ('ham',), [(False,), (False,)]).lattice
     assert [tuple(c) for c in t] == [((), ('ham',)), (('spam', 'eggs'), ())]
+
+
+def test_visualize(lattice):
+    gv = lattice.graphviz(object_sep='; ', property_sep='; ')
+    assert len(gv.body) > 0


### PR DESCRIPTION
- Lattice.graphviz now accepts an optional separators argument.
- The value should be a tuple.
- The first element of the tuple is the separator between objects, the second between properties.
- If not given, the default is to use spaces, as before.

I tried to rerun all tests after making this slight change, but I'm not sure they all ran.

Hope this is helpful.