### PR TITLE
Property Context.density and Definition.density

### DIFF
--- a/concepts/contexts.py
+++ b/concepts/contexts.py
@@ -712,6 +712,24 @@ class Context(ExportableMixin, LatticeMixin,
         """
         return _common.Shape._from_pair(self.objects, self.properties)
 
+    @tools.lazyproperty
+    def fill_ratio(self) -> float:
+        """The fill ratio (density of ``True`` values) of the context.
+
+        Fill ratio 0.25 means that 25% of the values in ``self.bools``
+        are ``True`` values.
+
+        Returns:
+            Context fill ratio (can be interpreted as percentages).
+
+        Example:
+            >>> import concepts
+            >>> context = concepts.Context.fromstring(concepts.EXAMPLE)
+            >>> context.fill_ratio
+            0.5
+        """
+        return sum(intent.count() for intent in self._intents) / (self.shape.objects * self.shape.properties)
+
     def definition(self) -> 'definitions.Definition':
         """Return ``(objects, properties, bools)`` triple as mutable object.
 

--- a/concepts/definitions.py
+++ b/concepts/definitions.py
@@ -898,3 +898,23 @@ class Definition(MutableMixin, TransformableMixin, FormattingMixin, Triple):
             Shape(objects=2, properties=1)
         """
         return _common.Shape._from_pair(self.objects, self.properties)
+
+    @property
+    def fill_ratio(self) -> float:
+        """The fill ratio (density of ``True`` values) of the definition.
+
+        Fill ratio 0.25 means that 25% of the values in ``self.bools`` are ``True``.
+
+        Returns:
+            Definition fill ratio (can be interpreted as percentages).
+
+        Example:
+            >>> import concepts
+            >>> definition = concepts.Definition(['King Arthur', 'grail'],
+            ...                                  ['holy', 'historic'],
+            ...                                  [(False, True), (True, True)])
+            >>> definition.fill_ratio
+            0.75
+        """
+        shape = self.shape
+        return len(self._pairs) / (shape.objects * shape.properties)


### PR DESCRIPTION
Simple `.density` property for `Context` and `Definition`. Calculated as ratio of `True` values vs maximum possible number of `True` values (size of the context) in `Context.bools`/`Definition.bools`. This information should be probably inside the docstring. It can be confusing what density of context means.

Useful for scientific experiments or other benchmark purposes.

If you think that property can be useful I will add docs and `CHANGES.txt`.