### PR TITLE
LazyLattice and LazyConcept

### DIFF
--- a/concepts/contexts.py
+++ b/concepts/contexts.py
@@ -9,6 +9,7 @@ from . import definitions
 from . import formats
 from . import junctors
 from . import lattices
+from . import lazy_lattices
 from . import matrices
 from . import tools
 
@@ -512,6 +513,15 @@ class LatticeMixin:
              lattices.Lattice: Cached or new :class:`lattices.Lattice` instance.
         """
         return lattices.Lattice(self)
+
+    @tools.lazyproperty 
+    def lazy_lattice(self) -> 'lazy_lattices.LazyLattice':
+        """The lazy concept lattice of the formal context.
+
+        Returns:
+             lazy_lattices.LazyLattice: Cached or new :class:`lazy_lattices.LazyLattice` instance.
+        """
+        return lazy_lattices.LazyLattice(self)
 
 
 class ExportableMixin:

--- a/concepts/lazy_lattice_members.py
+++ b/concepts/lazy_lattice_members.py
@@ -1,0 +1,93 @@
+import typing
+
+from .algorithms import lindig
+from .lattice_members import OrderableMixin
+
+
+class LazyPair:    
+    def __init__(self,
+                 lattice,
+                 extent,
+                 intent,
+                 upper=None,
+                 lower=None) -> None:
+        self.lattice = lattice
+        self._extent = extent
+        self._intent = intent
+        self._upper_neighbors = upper
+        self._lower_neighbors = lower
+    
+    @property
+    def upper_neighbors(self):
+        if self._upper_neighbors is None:
+            neighbors = lindig.neighbors(self._extent, Objects=self.lattice._context._Objects)
+            
+            shortlex = self.lattice._shortlex
+
+            upper = (self.lattice[extent.members()] for extent, _ in neighbors)
+            self._upper_neighbors = tuple(sorted(upper, key=shortlex))
+
+        return self._upper_neighbors
+    
+    @property
+    def lower_neighbors(self):
+        if self._lower_neighbors is None:
+            neighbors = lindig.neighbors(self._intent, Objects=self.lattice._context._Properties)
+            
+            longlex = self.lattice._longlex
+                
+            lower = (self.lattice[intent.members()] for intent, _ in neighbors)
+            self._lower_neighbors = tuple(sorted(lower, key=longlex))
+
+        return self._lower_neighbors
+    
+    def _eq(self, other):
+        if not isinstance(other, LazyConcept):
+            return NotImplemented
+
+        if (other._extent.members() != self._extent.members()
+            or other._intent.members() != self._intent.members()):
+            return False
+
+        return True
+
+
+class LazyRelationsMixin:
+    def incompatible_with(self, other: 'LazyConcept') -> bool:
+        return not self._extent & other._extent
+    
+
+class LazyTransformableMixin:
+    def join(self, other: 'LazyConcept') -> 'LazyConcept':
+        common = self._extent | other._extent
+        extent = self.lattice._context._extents.double(common)
+        return self.lattice[extent.members()]
+
+    __or__ = join
+
+    def meet(self, other: 'LazyConcept') -> 'LazyConcept':
+        common = self._extent & other._extent
+        extent = self.lattice._context._extents.double(common)
+        return self.lattice[extent.members()]
+
+    __and__ = meet
+
+
+class LazyFormattingMixin:
+    def __str__(self) -> str:
+        extent = ', '.join(self._extent.members())
+        intent = ' '.join(self._intent.members())
+        return f'{{{extent}}} <-> [{intent}]'
+
+    def __repr__(self) -> str:
+        return f'<{self.__class__.__name__} {self}>'
+
+
+class LazyConcept(LazyRelationsMixin, OrderableMixin, LazyFormattingMixin, LazyPair):
+    def minimal(self) -> typing.Tuple[str, ...]:
+        return self.lattice._context._minimal(self._extent,
+                                              self._intent).members()
+
+    def attributes(self) -> typing.Iterator[typing.Tuple[str]]:
+        minimize = self.lattice._context._minimize(self._extent, self._intent)
+        return (i.members() for i in minimize)

--- a/concepts/lazy_lattice_members.py
+++ b/concepts/lazy_lattice_members.py
@@ -41,6 +41,14 @@ class LazyPair:
 
         return self._lower_neighbors
     
+    @property
+    def extent(self) -> typing.Tuple[str, ...]:
+        return self._extent.members()
+
+    @property
+    def intent(self) -> typing.Tuple[str, ...]:
+        return self._intent.members()
+    
     def _eq(self, other):
         if not isinstance(other, LazyConcept):
             return NotImplemented

--- a/concepts/lazy_lattices.py
+++ b/concepts/lazy_lattices.py
@@ -1,102 +1,21 @@
 import typing
 
-from . import lattices
 from . import contexts
-from .algorithms import lindig
-
-from .lattice_members import OrderableMixin
-
-
-class LazyPair:    
-    def __init__(self,
-                 lattice,
-                 extent,
-                 intent,
-                 upper=None,
-                 lower=None) -> None:
-        self.lattice = lattice
-        self._extent = extent
-        self._intent = intent
-        self._upper_neighbors = upper
-        self._lower_neighbors = lower
-    
-    @property
-    def upper_neighbors(self):
-        if self._upper_neighbors is None:
-            neighbors = lindig.neighbors(self._extent, Objects=self.lattice._context._Objects)
-            
-            shortlex = self.lattice._shortlex
-
-            upper = (self.lattice[extent.members()] for extent, _ in neighbors)
-            self._upper_neighbors = tuple(sorted(upper, key=shortlex))
-
-        return self._upper_neighbors
-    
-    @property
-    def lower_neighbors(self):
-        if self._lower_neighbors is None:
-            neighbors = lindig.neighbors(self._intent, Objects=self.lattice._context._Properties)
-            
-            longlex = self.lattice._longlex
-
-            lower = (self.lattice[extent.members()] for _, extent in neighbors)
-            self._lower_neighbors = tuple(sorted(lower, key=longlex))
-
-        return self._lower_neighbors
-    
-    def _eq(self, other):
-        if not isinstance(other, LazyConcept):
-            return NotImplemented
-
-        if (other._extent.members() != self._extent.members()
-            or other._intent.members() != self._intent.members()):
-            return False
-
-        return True
-
-
-class LazyRelationsMixin:
-    def incompatible_with(self, other: 'LazyConcept') -> bool:
-        return not self._extent & other._extent
-    
-
-class LazyTransformableMixin:
-    def join(self, other: 'LazyConcept') -> 'LazyConcept':
-        common = self._extent | other._extent
-        extent = self.lattice._context._extents.double(common)
-        return self.lattice[extent.members()]
-
-    __or__ = join
-
-    def meet(self, other: 'LazyConcept') -> 'LazyConcept':
-        common = self._extent & other._extent
-        extent = self.lattice._context._extents.double(common)
-        return self.lattice[extent.members()]
-
-    __and__ = meet
-
+from .lazy_lattice_members import LazyConcept
+ 
 
 class LazyFormattingMixin:
     def __str__(self) -> str:
-        extent = ', '.join(self._extent.members())
-        intent = ' '.join(self._intent.members())
-        return f'{{{extent}}} <-> [{intent}]'
+        concepts = '\n'.join(f'    {c}' for c in self._concepts)
+        return f'{self!r}\n{concepts}'
 
     def __repr__(self) -> str:
-        return f'<{self.__class__.__name__} {self}>'
+        return (f'<{self.__class__.__name__} object'
+                f' {len(self)} concepts'
+                f' at {id(self):#x}>')
 
 
-class LazyConcept(LazyRelationsMixin, OrderableMixin, LazyFormattingMixin, LazyPair):
-    def minimal(self) -> typing.Tuple[str, ...]:
-        return self.lattice._context._minimal(self._extent,
-                                              self._intent).members()
-
-    def attributes(self) -> typing.Iterator[typing.Tuple[str]]:
-        minimize = self.lattice._context._minimize(self._extent, self._intent)
-        return (i.members() for i in minimize)
- 
-
-class LazyLattice(lattices.CollectionMixin, lattices.FormattingMixin):
+class LazyLattice(LazyFormattingMixin):
     @staticmethod
     def _longlex(concept):
         return concept._extent.longlex()
@@ -121,12 +40,23 @@ class LazyLattice(lattices.CollectionMixin, lattices.FormattingMixin):
 
         extent, intent = self._context.__getitem__(key, raw=True)
 
-        if extent not in self:
+        if extent not in self._mapping:
             new_concept = LazyConcept(self, extent, intent)
             self._mapping[extent] = new_concept
             self._concepts.append(new_concept)
+            self._concepts.sort(key=self._shortlex)
 
         return self._mapping[extent]
+    
+    def __iter__(self) -> typing.Iterator[LazyConcept]:
+        return iter(self._concepts)
+
+    def __len__(self) -> int:
+        return len(self._concepts)
+
+
+    
+
 
 
     

--- a/concepts/lazy_lattices.py
+++ b/concepts/lazy_lattices.py
@@ -1,0 +1,133 @@
+import typing
+
+from . import lattices
+from . import contexts
+from .algorithms import lindig
+
+from .lattice_members import OrderableMixin
+
+
+class LazyPair:    
+    def __init__(self,
+                 lattice,
+                 extent,
+                 intent,
+                 upper=None,
+                 lower=None) -> None:
+        self.lattice = lattice
+        self._extent = extent
+        self._intent = intent
+        self._upper_neighbors = upper
+        self._lower_neighbors = lower
+    
+    @property
+    def upper_neighbors(self):
+        if self._upper_neighbors is None:
+            neighbors = lindig.neighbors(self._extent, Objects=self.lattice._context._Objects)
+            
+            shortlex = self.lattice._shortlex
+
+            upper = (self.lattice[extent.members()] for extent, _ in neighbors)
+            self._upper_neighbors = tuple(sorted(upper, key=shortlex))
+
+        return self._upper_neighbors
+    
+    @property
+    def lower_neighbors(self):
+        if self._lower_neighbors is None:
+            neighbors = lindig.neighbors(self._intent, Objects=self.lattice._context._Properties)
+            
+            longlex = self.lattice._longlex
+
+            lower = (self.lattice[extent.members()] for _, extent in neighbors)
+            self._lower_neighbors = tuple(sorted(lower, key=longlex))
+
+        return self._lower_neighbors
+    
+    def _eq(self, other):
+        if not isinstance(other, LazyConcept):
+            return NotImplemented
+
+        if (other._extent.members() != self._extent.members()
+            or other._intent.members() != self._intent.members()):
+            return False
+
+        return True
+
+
+class LazyRelationsMixin:
+    def incompatible_with(self, other: 'LazyConcept') -> bool:
+        return not self._extent & other._extent
+    
+
+class LazyTransformableMixin:
+    def join(self, other: 'LazyConcept') -> 'LazyConcept':
+        common = self._extent | other._extent
+        extent = self.lattice._context._extents.double(common)
+        return self.lattice[extent.members()]
+
+    __or__ = join
+
+    def meet(self, other: 'LazyConcept') -> 'LazyConcept':
+        common = self._extent & other._extent
+        extent = self.lattice._context._extents.double(common)
+        return self.lattice[extent.members()]
+
+    __and__ = meet
+
+
+class LazyFormattingMixin:
+    def __str__(self) -> str:
+        extent = ', '.join(self._extent.members())
+        intent = ' '.join(self._intent.members())
+        return f'{{{extent}}} <-> [{intent}]'
+
+    def __repr__(self) -> str:
+        return f'<{self.__class__.__name__} {self}>'
+
+
+class LazyConcept(LazyRelationsMixin, OrderableMixin, LazyFormattingMixin, LazyPair):
+    def minimal(self) -> typing.Tuple[str, ...]:
+        return self.lattice._context._minimal(self._extent,
+                                              self._intent).members()
+
+    def attributes(self) -> typing.Iterator[typing.Tuple[str]]:
+        minimize = self.lattice._context._minimize(self._extent, self._intent)
+        return (i.members() for i in minimize)
+ 
+
+class LazyLattice(lattices.CollectionMixin, lattices.FormattingMixin):
+    @staticmethod
+    def _longlex(concept):
+        return concept._extent.longlex()
+
+    @staticmethod
+    def _shortlex(concept):
+        return concept._extent.shortlex()
+
+    def __init__(self, context: 'contexts.Context'):
+        self._context = context
+        self._concepts = []
+        self._mapping = {}
+
+    def __repr__(self) -> str:
+        return (f'<{self.__class__.__name__} object'
+                f' {len(self)} concepts'
+                f' at {id(self):#x}>')
+    
+    def __getitem__(self, key: typing.Tuple[str, ...]) -> LazyConcept:
+        if not key:
+            key = self._context._Objects.supremum.members()
+
+        extent, intent = self._context.__getitem__(key, raw=True)
+
+        if extent not in self:
+            new_concept = LazyConcept(self, extent, intent)
+            self._mapping[extent] = new_concept
+            self._concepts.append(new_concept)
+
+        return self._mapping[extent]
+
+
+    
+


### PR DESCRIPTION
Hi :)

I am currently testing WIP demo implementation of something i call LazyLattice (and LazyConcept).

Typical application is when you wanna construct Lattice with one concept and find its upper and lower neighbours (and nothing more).

Biggest priority was to keep the API as close as possible, because users could want to use Concept and LazyConcept as interchangeable arguments to other functions.

The whole magic is [here](https://github.com/mikulatomas/concepts/blob/6fc1b9c853e598ce73a7d7a50c863f09402909eb/concepts/lazy_lattice_members.py#L20) and [here](https://github.com/mikulatomas/concepts/blob/6fc1b9c853e598ce73a7d7a50c863f09402909eb/concepts/lazy_lattices.py#L37).

Are you interested in this feature in the main branch? It is still work in progress (no docstring, API not complete etc.). This feature is necessary for my research so I will implement i anyway (in [fcapsy package](https://github.com/mikulatomas/fcapsy), which should still keep compatibility).

Ideas are welcomed :) (btw I feel that this feature is more important than https://github.com/xflr6/concepts/pull/15)

Small demo:

```python
from concepts import Context

c = Context.fromstring('''
           |human|knight|king |mysterious|
King Arthur|  X  |  X   |  X  |          |
Sir Robin  |  X  |  X   |     |          |
holy grail |     |      |     |     X    |
''')

lazy_concept = c.lazy_lattice[["King Arthur"]]
# <LazyConcept {King Arthur} <-> [human knight king]>

len(c.lazy_lattice)
# 1

lazy_concept.upper_neighbors
# (<LazyConcept {King Arthur, Sir Robin} <-> [human knight]>,)

len(c.lazy_lattice)
# 2

lazy_concept.lower_neighbors
# (<LazyConcept {} <-> [human knight king mysterious]>,)

len(c.lazy_lattice)
# 3

lazy_concept.upper_neighbors
# (<LazyConcept {King Arthur, Sir Robin} <-> [human knight]>,)

len(c.lazy_lattice)
# 3 - nothing was added
```