### PR TITLE
Added support to download example datasets

### DIFF
--- a/concepts/__init__.py
+++ b/concepts/__init__.py
@@ -6,10 +6,11 @@ from ._common import Shape, ConceptList
 from ._example import EXAMPLE
 from .contexts import Context
 from .definitions import Definition
+from .examples import load_dataset
 
 __all__ = ['EXAMPLE',
            'Context', 'Definition', 'Shape',
-           'load', 'load_cxt', 'load_csv',
+           'load', 'load_cxt', 'load_csv', load_dataset,
            'make_context']
 
 __title__ = 'concepts'

--- a/concepts/examples.py
+++ b/concepts/examples.py
@@ -29,8 +29,8 @@ def load_dataset(name: str, data_src: typing.Optional[str] = DATASET_SOURCE,
 
     Example:
         >>> import concepts
-        >>> concepts.load_dataset('living_beings_and_water.cxt')
-        <Context object mapping 8 objects to 9 properties [b1e86589] at 0x...>
+        >>> concepts.load_dataset('livingbeings_en')
+        <Context object mapping 8 objects to 9 properties [e32693ba] at 0x...>
     """
 
     url = f"{data_src}/{name}.cxt"

--- a/concepts/examples.py
+++ b/concepts/examples.py
@@ -1,0 +1,40 @@
+"""Loading examplary formal contexts."""
+
+import typing
+from urllib.request import urlopen
+
+from .contexts import Context
+
+__all__ = ['load_dataset']
+
+DATASET_SOURCE = "https://raw.githubusercontent.com/fcatools/contexts/main/contexts"
+
+
+# inspired by https://github.com/mwaskom/seaborn/blob/master/seaborn/utils.py#L524
+def load_dataset(name: str, data_src: typing.Optional[str] = DATASET_SOURCE,
+                 encoding: typing.Optional[str] = 'utf-8'):
+    """Load an example formal context from the online repository (requires internet).
+
+    Args:
+        name (str):
+            Name of the dataset (``{name}.cxt`` on
+            https://github.com/fcatools/contexts/tree/main/contexts).
+        data_src (str, optional):
+            Base URL to the repository to download the dataset.
+        encoding (str, optional):
+            Encoding of the file (``'utf-8'``, ``'latin1'``, ``'ascii'``, ...).
+
+    Returns:
+        Context: New :class:`.Context` instance.
+
+    Example:
+        >>> import concepts
+        >>> concepts.load_dataset('living_beings_and_water.cxt')
+        <Context object mapping 8 objects to 9 properties [b1e86589] at 0x...>
+    """
+
+    url = f"{data_src}/{name}.cxt"
+
+    # TODO: implement caching here?
+
+    return Context.fromstring(urlopen(url).read().decode(encoding), 'cxt')

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -1,0 +1,10 @@
+import pytest
+
+import concepts
+
+
+def test_load_dataset():
+    context = concepts.load_dataset('livingbeings_en')
+
+    assert len(context.objects) == 8
+    assert len(context.properties) == 9


### PR DESCRIPTION
Dear Sebastian,

Inspired by other libraries (e.g., [Seaborn](https://seaborn.pydata.org/generated/seaborn.load_dataset.html) and [scikit-learn](https://scikit-learn.org/stable/datasets/toy_dataset.html)) I have added support to download exemplary contexts from the repository https://github.com/fcatools/contexts. For more context, please have a look at [this post on the FCA mailing list](https://lists.cs.uni-kassel.de/hyperkitty/list/fca-list@cs.uni-kassel.de/message/IUIXCLRLOREWFAPOGJQFDMKBMB2HSXEF/).

We can discuss details on how to properly handle, curate and implement this but I hope you like the idea. I'd happily make you (co)owner of the conexts repo or https://github.com/orgs/fcatools/ such that you have control over what can be loaded.